### PR TITLE
Update OPTIMADE Python tools dependency and more

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: Building GitHub pages (CI)
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install OPTIMADE
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r make_ghpages/requirements.txt
+
+    - name: Make pages
+      run: cd make_ghpages && python make_pages.py

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,11 +1,13 @@
 name: Building and deploying GitHub pages
 
 on:
+  # schedule runs _only_ for the default branch (for a repository) and the base branch (for a PR).
+  # See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule for more info.
   schedule:
     # See https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#scheduled-events-schedule
     # run every hour at xx:20
     - cron: "20 * * * *"
- 
+
 jobs:
   daily_build:
     runs-on: ubuntu-latest
@@ -14,19 +16,24 @@ jobs:
       COMMIT_AUTHOR_EMAIL: action@github.com
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.7
-    - name: Install OPTiMaDe
+        python-version: 3.8
+
+    - name: Install OPTIMADE
       run: |
         python -m pip install --upgrade pip
         pip install -r make_ghpages/requirements.txt
-    - name: make pages
+
+    - name: Make pages
       run: cd make_ghpages && python make_pages.py
-    - name: commit to gh-pages
+
+    - name: Commit to gh-pages
       run: ./make_ghpages/commit.sh
-    - name: push changes
+
+    - name: Push changes
       uses: ad-m/github-push-action@v0.5.0
       with:
         branch: gh-pages

--- a/make_ghpages/commit.sh
+++ b/make_ghpages/commit.sh
@@ -15,7 +15,7 @@ fi
 
 # Move html to temp dir
 mv make_ghpages/out ../page-build
-git checkout ${TARGET_BRANCH} || git checkout --orphan ${TARGET_BRANCH}
+git checkout "${TARGET_BRANCH}" || git checkout --orphan "${TARGET_BRANCH}"
 rm -rf * || exit 0
 cp -r ../page-build/* .
 

--- a/make_ghpages/commit.sh
+++ b/make_ghpages/commit.sh
@@ -1,23 +1,26 @@
-#!/bin/bash
-set -e # Exit with nonzero exit code if anything fails
+#!/usr/bin/env bash
 
-# commit sha of master branch
+# Exit with nonzero exit code if anything fails (-e)
+# Print all executed lines (-x)
+set -ex
+
+# Commit sha of master branch
 SHA=`git rev-parse --verify HEAD`
 TARGET_BRANCH="gh-pages"
 
-if [ "$GITHUB_ACTIONS" != "true" ]; then
+if [ "${GITHUB_ACTIONS}" != "true" ]; then
     echo "Skipping deploy; just doing a build."
     exit 0
 fi
 
-# move html to temp dir
+# Move html to temp dir
 mv make_ghpages/out ../page-build
-git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
+git checkout ${TARGET_BRANCH} || git checkout --orphan ${TARGET_BRANCH}
 rm -rf * || exit 0
 cp -r ../page-build/* .
 
-git config user.name "$COMMIT_AUTHOR"
-git config user.email "$COMMIT_AUTHOR_EMAIL"
+git config user.name "${COMMIT_AUTHOR}"
+git config user.email "${COMMIT_AUTHOR_EMAIL}"
 
 git add -A .
 # If there are no changes to the compiled out (e.g. this is a README update) then just bail.

--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -70,7 +70,7 @@ def get_index_metadb_data(base_url):
     # Let's continue, it was found
     try:
         json_response = json.loads(response_content)
-        info_response = IndexInfoResponse(**json_response)
+        IndexInfoResponse(**json_response)
     except Exception as exc:
         # Adapt the badge info
         provider_data['state'] = "validation error"
@@ -101,7 +101,7 @@ def get_index_metadb_data(base_url):
 
     try:
         links_json_response = json.loads(response_content)
-        links_response = LinksResponse(**links_json_response)
+        LinksResponse(**links_json_response)
     except Exception as exc:
         # Adapt the badge info
         provider_data['links_state'] = "validation error"

--- a/make_ghpages/requirements.txt
+++ b/make_ghpages/requirements.txt
@@ -1,4 +1,2 @@
-jinja2
-# This will need to be updated, pinning it to the first vesion that will
-# support the final v1 specs
-optimade==0.8.1
+jinja2==3.0.0a1
+optimade==0.10.0

--- a/make_ghpages/requirements.txt
+++ b/make_ghpages/requirements.txt
@@ -1,2 +1,2 @@
 jinja2==3.0.0a1
-optimade==0.10.0
+optimade~=0.10.0


### PR DESCRIPTION
This ~should fix issue~ will fix #1, however, I do not want to set an automatic closure of the issue in the case this update does _not_ fix the issue.
But after merging this, I suggest @merkys (as the issue author) to check whether the issue is solved and close it accordingly (or not) :)

The most important changes from this PR:
- Update `optimade` dependency to v0.10.0.
- Fix `jinja2` dependency to v3.0.0a1.
  It seems this was the version being installed in the GH Action runs, instead of the "stable" v2.
- Create `ci.yml` to test building the GitHub pages, i.e., testing `make_pages.py` runs as expected with any new changes.
  This runs only for PRs.

Minor updates in this PR:
- Remove unused variables from the Python file.
- Use Python 3.8 in the GH Action (instead of Python 3.7).
- Update the install Python action to v2.
- Set `-x` option for `commit.sh`, which will print out the executed commands.
- Use `/usr/bin/env bash` shebang instead of `/bin/bash`.
  This is more general.
- Wrap all variables in `commit.sh` in curly brackets (`{}`) to encourage future development to do the same, which will minimize erroneous parsing of the variable names in certain situations.

**Edit**: Based on [this comment](https://github.com/Materials-Consortia/providers-dashboard/pull/2#issuecomment-662350149) below, this PR does indeed fix #1.