### PR TITLE
Scheduled validation of child databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ extracted from [http://providers.optimade.org](http://providers.optimade.org).
 
 **In order to see the dashboard, go to [http://www.optimade.org/providers-dashboard/](http://www.optimade.org/providers-dashboard/)**.
 
-The dashboard page is automatically regenerated every hour via scheduled GitHub Actions (individual pages mention the last time the information was fetched).
+The dashboard page is automatically regenerated via scheduled GitHub Actions (individual pages mention the last time the information was fetched).

--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -9,6 +9,7 @@ import urllib.request
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 from optimade.models import IndexInfoResponse, LinksResponse
+from optimade.validator import ImplementationValidator
 
 # Subfolders
 OUT_FOLDER = 'out'
@@ -120,7 +121,20 @@ def get_index_metadb_data(base_url):
         key=lambda subdb: (subdb['id']!=provider_data['default_subdb'], subdb['id']))
 
     # Count the non-null ones
-    provider_data['num_non_null_subdbs'] = len([subdb for subdb in provider_data['subdbs'] if subdb['attributes']['base_url']])
+    non_null_subdbs = [subdb for subdb in provider_data["subdbs"] if subdb["attributes"]["base_url"]]
+    provider_data['num_non_null_subdbs'] = len(non_null_subdbs)
+
+    provider_data["subdb_validation"] = {}
+    for subdb in non_null_subdbs:
+        url = subdb["attributes"]["base_url"]
+        results = validate_childdb(url)
+        provider_data["subdb_validation"][url] = {}
+        provider_data["subdb_validation"][url]["valid"] = not results["failure_count"]
+        provider_data["subdb_validation"][url]["success_count"] = results["success_count"]
+        provider_data["subdb_validation"][url]["failure_count"] = results["failure_count"]
+        provider_data["subdb_validation"][url]["internal_errors"] = bool(results["internal_failure_count"])
+        # Count errors apart from internal errors
+        provider_data["subdb_validation"][url]["total_count"] = results["success_count"] + results["failure_count"]
 
     return provider_data
 
@@ -132,6 +146,33 @@ def get_html_provider_fname(provider_id):
     simple_string = "".join(c for c in provider_id if c in valid_characters)
 
     return "{}.html".format(simple_string)
+
+
+def validate_childdb(url: str) -> dict:
+    """ Run the optimade-python-tools validator on the child database.
+
+    Parameters:
+        url: the URL of the child database.
+
+    Returns:
+        dictionary representation of the validation results.
+
+    """
+    import dataclasses
+    from traceback import print_exc
+    validator = ImplementationValidator(
+        base_url=url,
+        run_optional_tests=False,
+        verbosity=-1,
+        fail_fast=False
+    )
+
+    try:
+        validator.validate_implementation()
+    except Exception:
+        print_exc()
+
+    return dataclasses.asdict(validator.results)
 
 
 def make_pages():

--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -135,6 +135,19 @@ def get_index_metadb_data(base_url):
         provider_data["subdb_validation"][url]["internal_errors"] = bool(results["internal_failure_count"])
         # Count errors apart from internal errors
         provider_data["subdb_validation"][url]["total_count"] = results["success_count"] + results["failure_count"]
+        ratio = results["success_count"] / (results["success_count"] + results["failure_count"])
+        # Use the red/green values from the badge css
+        ratio = 2 * (max(0.5, ratio) - 0.5)
+        green = (77, 175, 74)
+        red = (228, 26, 28)
+        colour = list(green)
+
+        for ind, channel in enumerate(colour):
+            gradient = red[ind] - green[ind]
+            colour[ind] += gradient * (1 - ratio)
+
+        colour = [str(int(channel)) for channel in colour]
+        provider_data["subdb_validation"][url]["_validator_results_colour"] = f"rgb({','.join(colour)});"
 
     return provider_data
 

--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -72,7 +72,17 @@
             <p><strong><a href="{{subdb.attributes.base_url | extract_url }}" target="_blank">{{subdb.attributes.name}}</strong></a>
         (<code>{{subdb.id}}{% if index_metadb.default_subdb == subdb.id %}, default sub-database{% endif %}</code>)
         </p>
-        <div>{{subdb.attributes.description}}</div>
+            <div>{{subdb.attributes.description}}</div>
+            {% if subdb.attributes.base_url %}
+                <span class="badge" style="display: table-row; line-height: 2; font-size: 0.8em;">
+                    <span style="display: table-cell; float: none; text-align: right;"><span class="badge-left blue tooltip" style="float: none; display: inline; text-align: right; border: none">Validation<span class="tooltiptext">Results of validation</span></span></span>
+                    {% if index_metadb.subdb_validation[subdb.attributes.base_url].valid %}
+                        <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right green tooltip" style="float: none; display: inline; text-align: left; border: none">Passed {{index_metadb.subdb_validation[subdb.attributes.base_url]['success_count']}} / {{index_metadb.subdb_validation[subdb.attributes.base_url]['total_count']}}</span></span>
+                    {% else %}
+                        <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right red tooltip" style="float: none; display: inline; text-align: left; border: none">Passed {{index_metadb.subdb_validation[subdb.attributes.base_url]['success_count']}} / {{index_metadb.subdb_validation[subdb.attributes.base_url]['total_count']}}</span></span>
+                    {% endif %}
+                </span>
+            {% endif %}
         </li>
         {% endfor %}
         </ul>

--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -76,11 +76,7 @@
             {% if subdb.attributes.base_url %}
                 <span class="badge" style="display: table-row; line-height: 2; font-size: 0.8em;">
                     <span style="display: table-cell; float: none; text-align: right;"><span class="badge-left blue tooltip" style="float: none; display: inline; text-align: right; border: none">Validation<span class="tooltiptext">Results of validation</span></span></span>
-                    {% if index_metadb.subdb_validation[subdb.attributes.base_url].valid %}
-                        <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right green tooltip" style="float: none; display: inline; text-align: left; border: none">Passed {{index_metadb.subdb_validation[subdb.attributes.base_url]['success_count']}} / {{index_metadb.subdb_validation[subdb.attributes.base_url]['total_count']}}</span></span>
-                    {% else %}
-                        <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right red tooltip" style="float: none; display: inline; text-align: left; border: none">Passed {{index_metadb.subdb_validation[subdb.attributes.base_url]['success_count']}} / {{index_metadb.subdb_validation[subdb.attributes.base_url]['total_count']}}</span></span>
-                    {% endif %}
+                    <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right tooltip" style="color: #fff; background-color: {{index_metadb['subdb_validation'][subdb.attributes.base_url]['_validator_results_colour']}}; float: none; display: inline; text-align: left; border: none">Passed {{index_metadb.subdb_validation[subdb.attributes.base_url]['success_count']}} / {{index_metadb.subdb_validation[subdb.attributes.base_url]['total_count']}}</span></span>
                 </span>
             {% endif %}
         </li>

--- a/make_ghpages/requirements.txt
+++ b/make_ghpages/requirements.txt
@@ -1,2 +1,2 @@
 jinja2==3.0.0a1
-optimade~=0.10.0
+optimade>=0.12.0


### PR DESCRIPTION
This PR starts the process described in #5 by calling the optimade-python-tools validator on every non-null child database, and adding a little badge showing how many tests it passed.

Screenshot for mcloud, as they have the largest number of sub-dbs:

![image](https://user-images.githubusercontent.com/7916000/94037008-d2c49900-fdbc-11ea-9677-f9c48e058e10.png)

~It feels a bit harsh marking these as "red" as the actual number of successes/failures is a bit arbitrary and depends on what is presented in the `/info`; perhaps this should be replaced by a "success ratio" or something. It would also be nice to click the button and get an expanded box showing the output of the validator, if anyone wants to have a go at that...~

