### PR TITLE
Append 'v1' to base URLs by default in case unversioned url not provided

### DIFF
--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -127,7 +127,7 @@ def get_index_metadb_data(base_url):
     provider_data["subdb_validation"] = {}
     for subdb in non_null_subdbs:
         url = subdb["attributes"]["base_url"]
-        results = validate_childdb(url)
+        results = validate_childdb(url + "/v1" if not url.endswith("/v1") else "")
         provider_data["subdb_validation"][url] = {}
         provider_data["subdb_validation"][url]["valid"] = not results["failure_count"]
         provider_data["subdb_validation"][url]["success_count"] = results["success_count"]


### PR DESCRIPTION
Currently Materials Project is unfairly penalised in the dashboard as it does not serve anything at its unversioned base URL. As unversioned URL support is optional, and this is the URL currently used for validation, this PR adds a `"/v1"` on the end of all base URLs. 

In future, it would be nice to use the versions endpoint (which must be served at the unversioned URL) to do this in a more robust way, but many implementations are still missing this.

I would consider this high priority, as I am supposed to be giving a talk on OPTIMADE in ~22 hours and would like to show a green dashboard!