### PR TITLE
Pin optimade-python-tools version and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,14 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: weekly
+    interval: daily
   target-branch: master
   labels:
   - dependency_updates
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: monthly
+    interval: daily
   target-branch: master
   labels:
   - CI

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+  target-branch: master
+  labels:
+  - dependency_updates
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly
+  target-branch: master
+  labels:
+  - CI

--- a/make_ghpages/requirements.txt
+++ b/make_ghpages/requirements.txt
@@ -1,2 +1,2 @@
 jinja2==3.0.0a1
-optimade>=0.12.0
+optimade==0.12.5


### PR DESCRIPTION
Closes #10.

optimade-python-tools 0.12.6 will include some validator fixes and should be released this week. If we get this PR in first then we have an immediate test that dependabot is set up correctly.