### PR TITLE
Add pre-commit and strip slashes from URLs prior to validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.4.0
+  hooks:
+  - id: trailing-whitespace
+    exclude: README.md
+  - id: check-yaml
+  - id: check-json
+
+- repo: https://github.com/ambv/black
+  rev: 20.8b1
+  hooks:
+  - id: black
+    name: Blacken
+
+- repo: https://gitlab.com/pycqa/flake8
+  rev: '3.8.4'
+  hooks:
+  - id: flake8

--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -160,7 +160,9 @@ def get_index_metadb_data(base_url):
     provider_data["subdb_validation"] = {}
     for subdb in non_null_subdbs:
         url = subdb["attributes"]["base_url"]
-        results = validate_childdb(url + "/v1" if not url.endswith("/v1") else "")
+        results = validate_childdb(
+            url.strip("/") + "/v1" if not url.endswith("/v1") else ""
+        )
         provider_data["subdb_validation"][url] = {}
         provider_data["subdb_validation"][url]["valid"] = not results["failure_count"]
         provider_data["subdb_validation"][url]["success_count"] = results[

--- a/make_ghpages/mod/templates/base.html
+++ b/make_ghpages/mod/templates/base.html
@@ -20,7 +20,7 @@
 </head>
 
 <body>
-    {% block header %} 
+    {% block header %}
     <header id='entrytitle' style="background-color: #000; margin: 0; padding: 5px 20px 25px 20px;">
         <h1>
             Materials Consortia's <a href="http://www.optimade.org" target="_blank">OPTIMADE</a> list of providers

--- a/make_ghpages/mod/templates/main_index.html
+++ b/make_ghpages/mod/templates/main_index.html
@@ -35,7 +35,7 @@
         {% for provider in providers %}
         <div class='submenu-entry'>
         <h2><code>{{provider.id}}</code>:
-            <a href="{{ provider.subpage }}">{{ provider.attributes.name }}</a> 
+            <a href="{{ provider.subpage }}">{{ provider.attributes.name }}</a>
         </h2>
 
         {% if provider.attributes.description %}

--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -26,9 +26,9 @@
         <p>
             <strong>Project homepage</strong>: <a href="{{ attributes.homepage }}" target="_blank"><code>{{ attributes.homepage }}</code></a>
         </p>
-        {% endif %}        
+        {% endif %}
         <p>
-            <strong>Index Meta-Database URL</strong>: 
+            <strong>Index Meta-Database URL</strong>:
             {%  if attributes.base_url %}
              <code>{{ attributes.base_url }}</code>
             {% else %}
@@ -46,12 +46,12 @@
             <span style="display: table-cell; float: none; text-align: right;"><span class="badge-left blue tooltip" style="float: none; display: inline; text-align: right; border: none">Index metaDB ({% if index_metadb.info_endpoint %}<a href="{{ index_metadb.info_endpoint }}" target="_blank">{% endif %}<code>/info</code>{% if index_metadb.info_endpoint %}</a>{% endif %})<span class="tooltiptext">State of the <code>/info</code> endpoint of the index meta-database</span></span></span>
             <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right {{ index_metadb.color }} tooltip" style="float: none; display: inline; text-align: left; border: none">{{ index_metadb.state }}<span class="tooltiptext">
                 {% if index_metadb.tooltip_lines %} {% for line in index_metadb.tooltip_lines %}{{ line }}<br />{% endfor %} {% else %} {{ index_metadb.state }} {% endif %}
-            </span></span></span>            
+            </span></span></span>
         </span>
         {% if index_metadb.version %}
         <span class="badge" style="display: table-row; line-height: 2;">
             <span style="display: table-cell; float: none; text-align: right;"><span class="badge-left blue tooltip" style="float: none; display: inline; text-align: right; border: none">Index metaDB version<span class="tooltiptext">Version of the index meta-database</span></span></span>
-            <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right dark-gray" style="float: none; display: inline; text-align: left; border: none">{{ index_metadb.version }}</span></span>            
+            <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right dark-gray" style="float: none; display: inline; text-align: left; border: none">{{ index_metadb.version }}</span></span>
         </span>
         {% endif %}
         {% if index_metadb.links_state %}
@@ -59,7 +59,7 @@
             <span style="display: table-cell; float: none; text-align: right;"><span class="badge-left blue tooltip" style="float: none; display: inline; text-align: right; border: none">Index metaDB ({% if index_metadb.links_endpoint %}<a href="{{ index_metadb.links_endpoint }}" target="_blank">{% endif %}<code>/links</code>{% if index_metadb.links_endpoint %}</a>{% endif %})<span class="tooltiptext">State of the <code>/links</code> endpoint of the index meta-database</span></span></span>
             <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right {{ index_metadb.links_color }} tooltip" style="float: none; display: inline; text-align: left; border: none">{{ index_metadb.links_state }}<span class="tooltiptext">
                 {% if index_metadb.links_tooltip_lines %} {% for line in index_metadb.links_tooltip_lines %}{{ line }}<br />{% endfor %} {% else %} {{ index_metadb.links_state }} {% endif %}
-            </span></span></span>            
+            </span></span></span>
         </span>
         {% endif %}
 

--- a/make_ghpages/static/css/style.css
+++ b/make_ghpages/static/css/style.css
@@ -19,7 +19,7 @@ main {
     margin-left: 16px;
     padding-top: 0px;
     margin-top: 0px;
-    margin-right: 16px; 
+    margin-right: 16px;
     padding-right: 0px;
     padding-bottom: 0px;
     margin-bottom: 0px;
@@ -222,7 +222,7 @@ td {
     text-align: center;
     padding: 3px;
     border-radius: 6px;
- 
+
     /* Position the tooltip text - see examples below! */
     position: absolute;
     z-index: 1;
@@ -249,25 +249,25 @@ td {
 }
 
 span.badge-left {
-    border-radius: .25rem;  
-    border-top-right-radius: 0; 
+    border-radius: .25rem;
+    border-top-right-radius: 0;
     border-bottom-right-radius: 0;
     color: #212529;
     background-color: #A2CBFF;
     /* color: #ffffff; */
     text-shadow: 1px 1px 1px rgba(0,0,0,0.3);
-    
+
     padding: .25em .4em;
     line-height: 0.8;
     text-align: center;
     white-space: nowrap;
     float: left;
-    display: block;  
+    display: block;
 }
 
 span.badge-right {
     border-radius: .25rem;
-    border-top-left-radius: 0; 
+    border-top-left-radius: 0;
     border-bottom-left-radius: 0;
 
     color: #fff;
@@ -278,7 +278,7 @@ span.badge-right {
     text-align: center;
     white-space: nowrap;
     float: left;
-    display: block;    
+    display: block;
 }
 
 .badge-right.light-blue, .badge-left.light-blue {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pre-commit~=2.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[flake8]
+ignore =
+    # Line to long. Handled by black.
+    E501
+    # Line break before binary operator. This is preferred formatting for black.
+    W503


### PR DESCRIPTION
Add `pre-commit` with the following hooks:

- trailing-whitespace (remove trailing whitespace, except for `README.md`)
- check-yaml
- check-json
- black (run the Black formatter for all Python files)
- flake8 (run the flake8 Python linter for all Python files)
  This is configured with `setup.cfg`.

Then this PR also fixes #14 by stripping all slashes (`/`) from the child DB URLs before validating to ensure that no double slash exists upon adding `/v1`.