### PR TITLE
Treat null value for 'aggregate' as 'ok', following the specification

### DIFF
--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -159,7 +159,9 @@ def get_index_metadb_data(base_url):
     provider_data["subdb_validation"] = {}
     for subdb in non_null_subdbs:
         url = subdb["attributes"]["base_url"]
-        if subdb["attributes"].get("aggregate", "ok") != "ok":
+        if aggregate := subdb["attributes"].get("aggregate") is None:
+            aggregate = "ok"
+        if aggregate != "ok":
             results = {}
             results["failure_count"] = 0
             results["success_count"] = 0


### PR DESCRIPTION
Closes #58.