### PR TITLE
List error messages per sub-database in dashboard

### DIFF
--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -177,6 +177,7 @@ def get_index_metadb_data(base_url):
         provider_data["subdb_validation"][url]["success_count"] = results[
             "success_count"
         ]
+        provider_data["subdb_validation"][url]["failure_messages"] = results["failure_messages"]
         provider_data["subdb_validation"][url]["failure_count"] = results[
             "failure_count"
         ]
@@ -303,6 +304,8 @@ def make_pages():
                     ).splitlines(),
                     "color": "orange",
                 }
+
+        provider_data["title"] = f'{provider_data["attributes"].get("name")}: OPTIMADE provider dashboard'
 
         # Write provider html
         provider_html = env.get_template("singlepage.html").render(**provider_data)

--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -163,27 +163,21 @@ def get_index_metadb_data(base_url):
             aggregate = "ok"
         if aggregate != "ok":
             results = {}
+            print(f"\t\tSkipping {subdb['id']} as aggregate is set to {aggregate}.")
             results["failure_count"] = 0
+            results["failure_messages"] = []
             results["success_count"] = 0
             results["internal_failure_count"] = 0
+            results["no_aggregate_reason"] = subdb["attributes"].get("no_aggregate_reason", "No reason given")
 
         else:
             results = validate_childdb(
                 url.strip("/") + "/v1" if not url.endswith("/v1") else ""
             )
+        results["aggregate"] = aggregate
 
-        provider_data["subdb_validation"][url] = {}
+        provider_data["subdb_validation"][url] = results
         provider_data["subdb_validation"][url]["valid"] = not results["failure_count"]
-        provider_data["subdb_validation"][url]["success_count"] = results[
-            "success_count"
-        ]
-        provider_data["subdb_validation"][url]["failure_messages"] = results["failure_messages"]
-        provider_data["subdb_validation"][url]["failure_count"] = results[
-            "failure_count"
-        ]
-        provider_data["subdb_validation"][url]["internal_errors"] = bool(
-            results["internal_failure_count"]
-        )
         # Count errors apart from internal errors
         provider_data["subdb_validation"][url]["total_count"] = (
             results["success_count"] + results["failure_count"]
@@ -208,6 +202,9 @@ def get_index_metadb_data(base_url):
         provider_data["subdb_validation"][url][
             "_validator_results_colour"
         ] = f"rgb({','.join(colour)});"
+
+        if provider_data["subdb_validation"][url].get("aggregate", "ok") != "ok":
+            provider_data["subdb_validation"][url]["_validator_results_colour"] = "DarkGrey"
 
     return provider_data
 

--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -319,13 +319,7 @@ def make_pages():
         all_provider_data, key=lambda provider: provider["id"]
     )
     all_data["globalsummary"] = {
-        "with_base_url": len(
-            [
-                provider
-                for provider in providers
-                if provider.get("attributes", {}).get("base_url") is not None
-            ]
-        ),
+        "with_base_url": len(all_data["providers"]),
         "num_sub_databases": sum(
             [
                 provider_data.get("index_metadb", {}).get("num_non_null_subdbs", 0)

--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -75,15 +75,24 @@
             <div>{{subdb.attributes.description}}</div>
             {% if subdb.attributes.base_url %}
                 <span class="badge" style="display: table-row; line-height: 2; font-size: 0.8em;">
-                    <span style="display: table-cell; float: none; text-align: right;"><span class="badge-left blue tooltip" style="float: none; display: inline; text-align: right; border: none">Validation<span class="tooltiptext">Results of validation</span></span></span>
-                    <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right tooltip" style="color: #fff; background-color: {{index_metadb['subdb_validation'][subdb.attributes.base_url]['_validator_results_colour']}}; float: none; display: inline; text-align: left; border: none">Passed {{index_metadb.subdb_validation[subdb.attributes.base_url]['success_count']}} / {{index_metadb.subdb_validation[subdb.attributes.base_url]['total_count']}}</span></span>
+                    {% if index_metadb.subdb_validation[subdb.attributes.base_url]['aggregate'] == 'ok' %}
+                        <span style="display: table-cell; float: none; text-align: right;"><span class="badge-left blue tooltip" style="float: none; display: inline; text-align: right; border: none">Validation<span class="tooltiptext">Results of validation</span></span></span>
+                        <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right tooltip" style="color: #fff; background-color: {{index_metadb['subdb_validation'][subdb.attributes.base_url]['_validator_results_colour']}}; float: none; display: inline; text-align: left; border: none">Passed {{index_metadb.subdb_validation[subdb.attributes.base_url]['success_count']}} / {{index_metadb.subdb_validation[subdb.attributes.base_url]['total_count']}}</span></span>
+                    {% else %}
+                        <span style="display: table-cell; float: none; text-align: right;"><span class="badge-left blue tooltip" style="float: none; display: inline; text-align: right; border: none">Aggregation is discouraged for this database<span class="tooltiptext">Results of validation</span></span></span>
+                        <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right tooltip" style="color: #fff; background-color: {{index_metadb['subdb_validation'][subdb.attributes.base_url]['_validator_results_colour']}}; float: none; display: inline; text-align: left; border: none"> {{ index_metadb.subdb_validation[subdb.attributes.base_url]['aggregate'] }}
+                            {% if index_metadb.subdb_validation[subdb.attributes.base_url]['no_aggregate_reason'] is not none %}}
+                                : {{ index_metadb.subdb_validation[subdb.attributes.base_url]['no_aggregate_reason'] }}
+                            {% endif %}
+                    </span></span>
+                    {% endif %}
                 </span>
-                {% if index_metadb.subdb_validation[subdb.attributes.base_url]['failure_messages'] %}
-                    <div class="errors" style="margin-top: 2em; width: 70%; font-family: monospace; font-size: 0.6em; background-color: Gainsboro; color: DimGrey; overflow: auto; white-space: nowrap; padding: 2em; border-radius: 3em;">
+                {% if index_metadb.subdb_validation[subdb.attributes.base_url].get('failure_messages') %}
+                    <div class="errors">
                         {% for message in index_metadb.subdb_validation[subdb.attributes.base_url]['failure_messages'] %}
-                        {% set bad_url = message[0].split("-")[0] %}
-                        <b>❌ <a href={{ bad_url }} style="text-decoration: underline; color: IndianRed;">{{ bad_url | safe }}</a></b> <br /><br />
-                        <p style="margin-left: 8em; color: ">{{ message[1].replace("\n", "<br />") | safe }}</p><br />
+                            {% set bad_url = message[0].split(" - ")[0] %}
+                            ❌ <a href="{{ bad_url }}">{{ bad_url | safe }}</a><br /><br />
+                            <p>{{ message[1].replace("\n", "<br />") | safe }}</p><br />
                         {% endfor %}
                 {% endif %}
             {% endif %}

--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -65,7 +65,7 @@
 
 
         {% if index_metadb.subdbs %}
-        <h3>Sub-databases provided by the provider</h3>
+        <h3>Databases served by this provider</h3>
         <ul>
         {% for subdb in index_metadb.subdbs %}
         <li>
@@ -78,6 +78,14 @@
                     <span style="display: table-cell; float: none; text-align: right;"><span class="badge-left blue tooltip" style="float: none; display: inline; text-align: right; border: none">Validation<span class="tooltiptext">Results of validation</span></span></span>
                     <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right tooltip" style="color: #fff; background-color: {{index_metadb['subdb_validation'][subdb.attributes.base_url]['_validator_results_colour']}}; float: none; display: inline; text-align: left; border: none">Passed {{index_metadb.subdb_validation[subdb.attributes.base_url]['success_count']}} / {{index_metadb.subdb_validation[subdb.attributes.base_url]['total_count']}}</span></span>
                 </span>
+                {% if index_metadb.subdb_validation[subdb.attributes.base_url]['failure_messages'] %}
+                    <div class="errors" style="margin-top: 2em; width: 70%; font-family: monospace; font-size: 0.6em; background-color: Gainsboro; color: DimGrey; overflow: auto; white-space: nowrap; padding: 2em; border-radius: 3em;">
+                        {% for message in index_metadb.subdb_validation[subdb.attributes.base_url]['failure_messages'] %}
+                        {% set bad_url = message[0].split("-")[0] %}
+                        <b>❌ <a href={{ bad_url }} style="text-decoration: underline; color: IndianRed;">{{ bad_url | safe }}</a></b> <br /><br />
+                        <p style="margin-left: 8em; color: ">{{ message[1].replace("\n", "<br />") | safe }}</p><br />
+                        {% endfor %}
+                {% endif %}
             {% endif %}
         </li>
         {% endfor %}

--- a/make_ghpages/static/css/style.css
+++ b/make_ghpages/static/css/style.css
@@ -390,3 +390,30 @@ ul.provider-info li:before {
   content: "→";
   padding-right: 5px;
 }
+
+.errors {
+    margin-top: 1em;
+    margin-bottom: 2em;
+    max-height: 200px;
+    width: 85%;
+    font-weight: bold;
+    font-family: monospace;
+    background-color: Gainsboro;
+    color: DimGrey;
+    overflow-x: auto;
+    overflow-y: auto;
+    white-space: nowrap;
+    padding: 1em;
+    border: 1px solid IndianRed;
+}
+
+.errors a {
+    text-decoration: underline;
+    color: IndianRed;
+}
+
+.errors p {
+    color: DimGrey;
+    padding-left: 3em;
+    font-weight: normal;
+}


### PR DESCRIPTION
This PR displays the errors associated with a sub-database in the database list.

Closes #8, hopefully, though could be made more aesthetic (e.g. collapsible boxes, better styling).

Also fixes:
- [x] the number of 'available providers' which was always showing 0
- [x] databases with discouraged aggregation were marked as "0/0", now the aggregation status is displayed (closes #26).

Error display looks something like:

![2021-09-20-113936_1154x517_scrot](https://user-images.githubusercontent.com/7916000/133989495-7440e215-22f4-47df-9c5d-3b9c6eb4be96.png)




