### PR TITLE
Add a per-db timeout to the dashboard validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,14 @@ on: [pull_request]
 
 jobs:
   build:
+
     runs-on: ubuntu-latest
+    
+    # Cancel running workflows when additional changes are pushed
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
+    concurrency:
+      group: ${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
     steps:
     - uses: actions/checkout@v2

--- a/make_ghpages/requirements.txt
+++ b/make_ghpages/requirements.txt
@@ -1,2 +1,2 @@
 jinja2==3.0.3
-optimade[server]==0.16.8
+optimade[server]==0.16.9


### PR DESCRIPTION
This PR wraps database validation with a context manager that adds a 10 minute timeout per database, after which point an additional test failure is added to the validation indicating that the timeout was reached. This does not invalidate any of the other tests performed on that database (and thus it could lead to misreporting).
