### PR TITLE
Link to useful endpoints in provider/db list

### DIFF
--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -14,7 +14,6 @@
     <p><a href="../index.html">&lt; back to the full provider list</a></p>
 
 
-
     <h2>General information</h2>
     <div>
         {%  if attributes.description %}
@@ -69,10 +68,10 @@
         <ul>
         {% for subdb in index_metadb.subdbs %}
         <li>
-            <p><strong><a href="{{subdb.attributes.base_url | extract_url }}" target="_blank">{{subdb.attributes.name}}</strong></a>
+            <p><strong><a href="{{subdb.attributes.base_url | extract_url }}/v1/info" target="_blank">{{subdb.attributes.name}}</strong></a>
         (<code>{{subdb.id}}{% if index_metadb.default_subdb == subdb.id %}, default sub-database{% endif %}</code>)
         </p>
-        <p><strong><a href="{{subdb.attributes.base_url | extract_url }}" target="_blank">{{subdb.attributes.base_url | extract_url}}</strong></a></p>
+        <p><strong><a href="{{subdb.attributes.base_url | extract_url }}/v1/info" target="_blank">{{subdb.attributes.base_url | extract_url}}</strong></a></p>
             <div>{{subdb.attributes.description}}</div>
             {% if subdb.attributes.base_url %}
                 <span class="badge" style="display: table-row; line-height: 2; font-size: 0.8em;">

--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -29,7 +29,7 @@
         <p>
             <strong>Index Meta-Database URL</strong>:
             {%  if attributes.base_url %}
-                <a href="{{ attributes.base_url }}" target="_blank"><code>{{ attributes.base_url }}</code></a>
+                <a href="{{ attributes.base_url }}/v1/links" target="_blank"><code>{{ attributes.base_url }}</code></a>
             {% else %}
             This provider did not specify yet a <code>base_url</code> for its OPTIMADE implementation.
             {% endif %}


### PR DESCRIPTION
Following #105, this PR adjusts the links listed for each child database to the `/v1/info` endpoint, and to `/v1/links` for each index meta-database rather than landing pages which could possibly 404.