### PR TITLE
Fix structure count and other tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OPTIMADE dashboard of known providers
 
 This repository contains the code to generate the dashboard of known providers,
-extracted from [http://providers.optimade.org](http://providers.optimade.org).
+extracted from [https://providers.optimade.org](https://providers.optimade.org).
 
-**In order to see the dashboard, go to [http://www.optimade.org/providers-dashboard/](http://www.optimade.org/providers-dashboard/)**.
+**In order to see the dashboard, go to [https://www.optimade.org/providers-dashboard/](https://www.optimade.org/providers-dashboard/)**.
 
 The dashboard page is automatically regenerated via scheduled GitHub Actions (individual pages mention the last time the information was fetched).

--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -13,7 +13,7 @@ from jinja2 import Environment, PackageLoader, select_autoescape
 from optimade.models import IndexInfoResponse, LinksResponse
 from optimade.validator import ImplementationValidator
 from optimade.validator.utils import ResponseError
-from optimade.server.routers.utils import get_providers
+from optimade.utils import get_providers
 from optimade import __version__
 
 # Subfolders
@@ -292,7 +292,11 @@ def _get_structure_count(url: str) -> int:
     try:
         with urllib.request.urlopen(f"{url}/structures") as url_response:
             response_content = json.loads(url_response.read())
-            return response_content.get("meta", {}).get("data_available", 0)
+            # account for inconsistencies in the metadata by taking largest of available/returned data
+            return max(
+                response_content.get("meta", {}).get("data_available", 0),
+                response_content.get("meta", {}).get("data_returned", 0),
+            )
 
     except Exception as exc:
         print(exc)

--- a/make_ghpages/mod/templates/base.html
+++ b/make_ghpages/mod/templates/base.html
@@ -25,7 +25,7 @@
         <h1>
             Materials Consortia's <a href="http://www.optimade.org" target="_blank">OPTIMADE</a> list of providers
         </h1>
-        <p style="font-size: 90%;"><a href="http://github.com/Materials-Consortia/providers-dashboard" style="color: #999;">[View on GitHub/list your provider]</a> </p>
+        <p style="font-size: 90%;">[<a href="http://github.com/Materials-Consortia/providers-dashboard" style="color: #999;">View on GitHub</a>/<a href="https://github.com/Materials-Consortia/providers" style="color: #999;">List your provider</a>] </p>
       </header>
 
     {% endblock header %}

--- a/make_ghpages/mod/templates/base.html
+++ b/make_ghpages/mod/templates/base.html
@@ -23,9 +23,9 @@
     {% block header %}
     <header id='entrytitle' style="background-color: #000; margin: 0; padding: 5px 20px 25px 20px;">
         <h1>
-            Materials Consortia's <a href="http://www.optimade.org" target="_blank">OPTIMADE</a> list of providers
+            Materials Consortia's <a href="https://www.optimade.org" target="_blank">OPTIMADE</a> list of providers
         </h1>
-        <p style="font-size: 90%;">[<a href="http://github.com/Materials-Consortia/providers-dashboard" style="color: #999;">View on GitHub</a>/<a href="https://github.com/Materials-Consortia/providers" style="color: #999;">List your provider</a>] </p>
+        <p style="font-size: 90%;">[<a href="https://github.com/Materials-Consortia/providers-dashboard" style="color: #999;">View on GitHub</a>/<a href="https://github.com/Materials-Consortia/providers" style="color: #999;">List your provider</a>] </p>
       </header>
 
     {% endblock header %}

--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -34,6 +34,9 @@
             This provider did not specify yet a <code>base_url</code> for its OPTIMADE implementation.
             {% endif %}
         </p>
+        <p>
+            <strong>Number of structures</strong>: {{ num_structures }}
+        </p>
     </div>
 
     <h2>


### PR DESCRIPTION
Closes #108 -- essentially NOMAD can only list 10000 structures as `data_available` and this value was being used instead of `data_returned` which is much larger. 

- Adds the number of structures per provider to the dashboard for verification (just in a low-key way).
- Tweaks some of the links to use https/links to the real providers repo.
- Uses a user-agent header to get around Materials Project's API protection